### PR TITLE
23 fix history end date in self healing function of daily maintenance service

### DIFF
--- a/bootstrap_service/Dockerfile
+++ b/bootstrap_service/Dockerfile
@@ -6,8 +6,8 @@ WORKDIR /app
 # Copy pre-built wheels
 COPY --from=wheels /wheels /wheels
 
-RUN pip install --user --no-cache-dir /wheels/weather_models-0.3.1-py3-none-any.whl
-RUN pip install --user --no-cache-dir /wheels/openmeteo_client-0.1.2-py3-none-any.whl
+RUN pip install --user --no-cache-dir /wheels/weather_models-0.3.2-py3-none-any.whl
+RUN pip install --user --no-cache-dir /wheels/openmeteo_client-0.1.3-py3-none-any.whl
 
 FROM python:3.13.7-slim-trixie
 

--- a/daily_maintenance_service/Dockerfile
+++ b/daily_maintenance_service/Dockerfile
@@ -6,8 +6,8 @@ WORKDIR /app
 # Copy pre-built wheels
 COPY --from=wheels /wheels /wheels
 
-RUN pip install --user --no-cache-dir /wheels/weather_models-0.3.1-py3-none-any.whl
-RUN pip install --user --no-cache-dir /wheels/openmeteo_client-0.1.2-py3-none-any.whl
+RUN pip install --user --no-cache-dir /wheels/weather_models-0.3.2-py3-none-any.whl
+RUN pip install --user --no-cache-dir /wheels/openmeteo_client-0.1.3-py3-none-any.whl
 
 
 FROM python:3.13.7-slim-trixie

--- a/forecast_build_service/Dockerfile
+++ b/forecast_build_service/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 # Copy pre-built wheels
 COPY --from=wheels /wheels /wheels
 
-RUN pip install --user --no-cache-dir /wheels/weather_models-0.3.1-py3-none-any.whl
+RUN pip install --user --no-cache-dir /wheels/weather_models-0.3.2-py3-none-any.whl
 
 FROM python:3.13.7-slim-trixie
 

--- a/forecast_service/Dockerfile
+++ b/forecast_service/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 # Copy pre-built wheels
 COPY --from=wheels /wheels /wheels
 
-RUN pip install --user --no-cache-dir /wheels/weather_models-0.3.1-py3-none-any.whl
+RUN pip install --user --no-cache-dir /wheels/weather_models-0.3.2-py3-none-any.whl
 
 FROM python:3.13.7-slim-trixie
 

--- a/openmeteo_client/openmeteo_client.py
+++ b/openmeteo_client/openmeteo_client.py
@@ -1121,7 +1121,7 @@ class OpenMeteoArchiveClient(OpenMeteoClient):
                 )
                 end_date = (
                     date(year, 12, 31)
-                    if year < date.today().year
+                    if date(year, 12, 31) < self.config.history_end_date
                     else self.config.history_end_date
                 )
                 fractional_query_params = {

--- a/openmeteo_client/pyproject.toml
+++ b/openmeteo_client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openmeteo-client"
-version = "0.1.2"
+version = "0.1.3"
 description = ""
 authors = [{ name = "Jonas Werner", email = "werner-jonas@outlook.com" }]
 readme = "README.md"

--- a/weather_models/pyproject.toml
+++ b/weather_models/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "weather_models"
-version = "0.3.1"
+version = "0.3.2"
 description = ""
 authors = [{ name = "Jonas Werner", email = "werner-jonas@outlook.com" }]
 readme = "README.md"

--- a/weather_models/weather_models.py
+++ b/weather_models/weather_models.py
@@ -611,6 +611,10 @@ class WeatherDatabase:
             datum for datum in expected_dates if datum not in available_dates
         ]
 
+        self.logger.info(
+            f"Database is missing the entries for the following dates: {missing_dates}"
+        )
+
         return missing_dates
 
     def get_date_range(

--- a/weather_models/weather_models.py
+++ b/weather_models/weather_models.py
@@ -575,7 +575,7 @@ class WeatherDatabase:
             return True
         else:
             self.logger.info(
-                f"Data does not contain all expected dates. Expected start date: {start_date} Expected end date: {end_date} Got: {available_dates}"
+                f"Data does not contain all expected dates. Expected start date: {start_date} Expected end date: {end_date}"
             )
             return False
 

--- a/weekly_maintenance_service/Dockerfile
+++ b/weekly_maintenance_service/Dockerfile
@@ -6,8 +6,8 @@ WORKDIR /app
 # Copy pre-built wheels
 COPY --from=wheels /wheels /wheels
 
-RUN pip install --user --no-cache-dir /wheels/weather_models-0.3.1-py3-none-any.whl
-RUN pip install --user --no-cache-dir /wheels/openmeteo_client-0.1.2-py3-none-any.whl
+RUN pip install --user --no-cache-dir /wheels/weather_models-0.3.2-py3-none-any.whl
+RUN pip install --user --no-cache-dir /wheels/openmeteo_client-0.1.3-py3-none-any.whl
 
 
 FROM python:3.13.7-slim-trixie


### PR DESCRIPTION
This pull request addresses a bug in the OpenMeteo client's history end date handling

**Package version updates:**

* Updated all service Dockerfiles (`bootstrap_service`, `daily_maintenance_service`, `forecast_build_service`, `forecast_service`, `weekly_maintenance_service`) to install `weather_models` version `0.3.2` and `openmeteo_client` version `0.1.3` where applicable. [[1]](diffhunk://#diff-2a14d6a2872c880fba2bee7bd45681bc1eb3f053498595580819a944b50a3d5eL9-R10) [[2]](diffhunk://#diff-fc53606be62c910ec6b1671dc3e49f00bf92dc9e5cdc325561948b252c96ce04L9-R10) [[3]](diffhunk://#diff-d66b3e4880197836167cbe36e4162f7ad5046839c215f5462d655d9d6d9dfc3bL9-R9) [[4]](diffhunk://#diff-3751fa289ea3d3263be35fc0d13c2590ca514d142b227efe6f7b2f0658812533L9-R9) [[5]](diffhunk://#diff-62737bdde9eac6034fdd40dee08a28ebbc8b1ef0ced2fef04ba83dedebf7c18cL9-R10)
* Updated `weather_models/pyproject.toml` to version `0.3.2`.
* Updated `openmeteo_client/pyproject.toml` to version `0.1.3`.

**Code improvements:**

* Improved logging in `weather_models.py` to report missing date entries in the database with a new log message in `get_missing_dates`.
* Simplified the log message in `__check_date_range` to remove redundant information about available dates.
* Fixed a date comparison in `openmeteo_client.py` to consistently use `self.config.history_end_date` for determining the end date.