### PR TITLE
install latest versions by default

### DIFF
--- a/bootstrap_service/Dockerfile
+++ b/bootstrap_service/Dockerfile
@@ -6,8 +6,7 @@ WORKDIR /app
 # Copy pre-built wheels
 COPY --from=wheels /wheels /wheels
 
-RUN pip install --user --no-cache-dir /wheels/weather_models-0.3.2-py3-none-any.whl
-RUN pip install --user --no-cache-dir /wheels/openmeteo_client-0.1.3-py3-none-any.whl
+RUN pip install --user --no-cache-dir --find-links /wheels openmeteo_client weather_models
 
 FROM python:3.13.7-slim-trixie
 

--- a/daily_maintenance_service/Dockerfile
+++ b/daily_maintenance_service/Dockerfile
@@ -6,9 +6,7 @@ WORKDIR /app
 # Copy pre-built wheels
 COPY --from=wheels /wheels /wheels
 
-RUN pip install --user --no-cache-dir /wheels/weather_models-0.3.2-py3-none-any.whl
-RUN pip install --user --no-cache-dir /wheels/openmeteo_client-0.1.3-py3-none-any.whl
-
+RUN pip install --user --no-cache-dir --find-links /wheels openmeteo_client weather_models
 
 FROM python:3.13.7-slim-trixie
 

--- a/forecast_build_service/Dockerfile
+++ b/forecast_build_service/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 # Copy pre-built wheels
 COPY --from=wheels /wheels /wheels
 
-RUN pip install --user --no-cache-dir /wheels/weather_models-0.3.2-py3-none-any.whl
+RUN pip install --user --no-cache-dir --find-links /wheels weather_models
 
 FROM python:3.13.7-slim-trixie
 

--- a/forecast_service/Dockerfile
+++ b/forecast_service/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 # Copy pre-built wheels
 COPY --from=wheels /wheels /wheels
 
-RUN pip install --user --no-cache-dir /wheels/weather_models-0.3.2-py3-none-any.whl
+RUN pip install --user --no-cache-dir --find-links /wheels weather_models
 
 FROM python:3.13.7-slim-trixie
 

--- a/weekly_maintenance_service/Dockerfile
+++ b/weekly_maintenance_service/Dockerfile
@@ -6,9 +6,7 @@ WORKDIR /app
 # Copy pre-built wheels
 COPY --from=wheels /wheels /wheels
 
-RUN pip install --user --no-cache-dir /wheels/weather_models-0.3.2-py3-none-any.whl
-RUN pip install --user --no-cache-dir /wheels/openmeteo_client-0.1.3-py3-none-any.whl
-
+RUN pip install --user --no-cache-dir --find-links /wheels openmeteo_client weather_models
 
 FROM python:3.13.7-slim-trixie
 


### PR DESCRIPTION
This pull request updates the way Python dependencies are installed in the Dockerfiles for services. The main change is switching from installing specific wheel files directly to using `pip install` with the `--find-links` option, which allows pip to resolve dependencies from the local `/wheels` directory. This change allows pip to automatically resolve the latest available versions from the local wheels directory, simplifying version management and making updates easier.

Dependency installation improvements:

* Changed `pip install` commands in `bootstrap_service/Dockerfile`, `daily_maintenance_service/Dockerfile`, and `weekly_maintenance_service/Dockerfile` to install `openmeteo_client` and `weather_models` using `--find-links /wheels` instead of specifying exact wheel files. [[1]](diffhunk://#diff-2a14d6a2872c880fba2bee7bd45681bc1eb3f053498595580819a944b50a3d5eL9-R9) [[2]](diffhunk://#diff-fc53606be62c910ec6b1671dc3e49f00bf92dc9e5cdc325561948b252c96ce04L9-R9) [[3]](diffhunk://#diff-62737bdde9eac6034fdd40dee08a28ebbc8b1ef0ced2fef04ba83dedebf7c18cL9-R9)
* Updated `pip install` commands in `forecast_build_service/Dockerfile` and `forecast_service/Dockerfile` to install `weather_models` using `--find-links /wheels`, removing the need to specify the exact wheel file. [[1]](diffhunk://#diff-d66b3e4880197836167cbe36e4162f7ad5046839c215f5462d655d9d6d9dfc3bL9-R9) [[2]](diffhunk://#diff-3751fa289ea3d3263be35fc0d13c2590ca514d142b227efe6f7b2f0658812533L9-R9)