### PR TITLE
43 bootstrap from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ Initializes the weather service database and populates it with historical data:
 - Fetches current forecast data
 - Generates weekly aggregations from daily data
 - Prevents accidental data overwrites via bootstrap detection
+- Supports bootstrapping from a file or directly from API
 
 ### Daily Maintenance Service
 
@@ -424,6 +425,10 @@ POSTGRES_PASSWORD=pw
 
 # Open Meteo client config file
 CONFIG_FILE=dev_config.json
+
+# Bootstrapping behavior
+BOOTSTRAP_MODE=from_file
+BOOTSTRAP_FILE=/path/to/file # Can be omitted if default path is used
 ```
 
 ### Adding New Services

--- a/bootstrap_service/bootstrap.py
+++ b/bootstrap_service/bootstrap.py
@@ -109,7 +109,7 @@ if __name__ == "__main__":
                     data=historic_data_daily, table=DailyWeatherHistory
                 )
             else:
-                logger.info("Bootstrapping historic date from file...")
+                logger.info("Bootstrapping historic data from file...")
                 historic_data_daily = pd.read_csv(BOOTSTRAP_FILE)
                 history_orm_objects_daily = database.create_orm_objects(
                     data=historic_data_daily, table=DailyWeatherHistory

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,6 +45,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       CONFIG_FILE: ${CONFIG_FILE}
+      BOOTSTRAP_MODE: ${BOOTSTRAP_MODE}
     depends_on:
       database:
         condition: service_healthy

--- a/openmeteo_client/openmeteo_client.py
+++ b/openmeteo_client/openmeteo_client.py
@@ -37,7 +37,7 @@ Geographic Processing:
 - Coordinate grid generation from bounding boxes
 - Multi-location request optimization
 - Spatial data integrity across all operations
-- Configurable grid resolution (default 0.5° spacing)
+- Configurable grid resolution (default 2.0° spacing)
 
 Temporal Management:
 - Automatic date range calculations
@@ -377,7 +377,7 @@ class OpenMeteoClientConfig:
         """
         return date.today() - timedelta(days=2)
 
-    def __create_locations(self, bounding_box: Any, step: float = 0.5) -> NDArray:
+    def __create_locations(self, bounding_box: Any, step: float = 2.0) -> NDArray:
         """Generate coordinate grid from geographic bounding box.
 
         Creates a regular grid of latitude and longitude coordinates within the
@@ -389,7 +389,7 @@ class OpenMeteoClientConfig:
                 Expected schema: {"north": float, "south": float, "east": float, "west": float}
                 All values should be in decimal degrees.
             step (float, optional): Grid spacing in decimal degrees for both
-                latitude and longitude. Defaults to 0.5 degrees (~55km at equator).
+                latitude and longitude. Defaults to 2 degrees.
 
         Returns:
             NDArray: 2D numpy array where each row contains [latitude, longitude]


### PR DESCRIPTION
This pull request adds support for initializing the weather service database using either historical data from a CSV file or directly from the OpenMeteo API. It introduces new configuration options to control the bootstrap mode and file path, updates documentation, and modifies the bootstrap logic to handle both data sources. These changes improve flexibility for development and deployment environments.

**Bootstrap mode support and configuration:**

* Added support for initializing historical weather data from either the OpenMeteo Archive API or a CSV file, controlled by the new `BOOTSTRAP_MODE` environment variable in `bootstrap_service/bootstrap.py` and documented in `README.md`. [[1]](diffhunk://#diff-0a985fd5c3f4b19c67d6715b284594a6582ce2de20fdc40bab1328c0fd00c55cL10-R10) [[2]](diffhunk://#diff-0a985fd5c3f4b19c67d6715b284594a6582ce2de20fdc40bab1328c0fd00c55cR19-R23) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R271)
* Introduced `BOOTSTRAP_FILE` environment variable to specify the CSV file path for file-based bootstrapping, with sensible defaults and documentation updates. [[1]](diffhunk://#diff-0a985fd5c3f4b19c67d6715b284594a6582ce2de20fdc40bab1328c0fd00c55cR46-R63) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R428-R431)

**Code changes for bootstrap logic:**

* Refactored `bootstrap_service/bootstrap.py` to read historical data from a CSV file when `BOOTSTRAP_MODE` is set to `from_file`, using pandas for file loading. [[1]](diffhunk://#diff-0a985fd5c3f4b19c67d6715b284594a6582ce2de20fdc40bab1328c0fd00c55cR79-R83) [[2]](diffhunk://#diff-0a985fd5c3f4b19c67d6715b284594a6582ce2de20fdc40bab1328c0fd00c55cR105-L107)

**Environment and deployment support:**

* Updated `docker-compose.yaml` to pass the new `BOOTSTRAP_MODE` environment variable to the bootstrap service for containerized deployments.