### PR TITLE
Update horizon value in config.json to 260

### DIFF
--- a/forecast_service/config.json
+++ b/forecast_service/config.json
@@ -1,3 +1,3 @@
 {
-    "horizon": 52
+    "horizon": 260
 }


### PR DESCRIPTION
This pull request makes a small configuration change to the `forecast_service` by increasing the forecast horizon from 52 to 260. This will allow the service to generate forecasts further into the future.